### PR TITLE
:technologist: Add toolchain.cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,66 +20,11 @@ Drivers for ARM cortex-m series micro-controllers. Currently supports:
 
 ## [Installing libhal prereqs](https://libhal.github.io/setup/)
 
-## Installing Arm GNU Toolchain
-
-> NOTE: These install steps are not the only possible way to install these
-> binaries, just that these are very easy ways to install these prereqs.
-
-**Required ARM cross compiler is `arm-none-eabi-g++` version 11.0 or above**
-
-### Mac OSX
-
-```zsh
-brew install --cask gcc-arm-embedded
-```
-
-### Linux
-
-> The version (10.2.1) used here is too old for libhal which requires 11.3 and
-> above. So you must use the steps below
->
-> ```
-> sudo apt install gcc-arm-none-eabi
-> ```
-
-Link to the linux binaries: [Arm GNU Toolchain
-Downloads](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
-
-You will also need to add this to your shell's `PATH` variable as well. Or use
-the argument `-DTOOLCHAIN_PATH="path/to/your/gnu-arm-toolchain"
-
-### Windows
-
-> The version (10.2.1) used here is too old for libhal which requires 11.3 and
-> above. So you must use the steps below
->
->```
->choco install gcc-arm-embedded
->```
-
-Click this link to download the Windows toolchain installer.
-
-[arm-gnu-toolchain-11.3.rel1-mingw-w64-i686-arm-none-eabi.exe](https://developer.arm.com/-/media/Files/downloads/gnu/11.3.rel1/binrel/arm-gnu-toolchain-11.3.rel1-mingw-w64-i686-arm-none-eabi.exe?rev=674f6ef06614499dad033db88c3452b3&hash=B2AAC9DBE66448116B07ED6C0BB7B71EAD875426)
-
-NOTE: At the end of the installation program make sure to check the box for
-**"Add to PATH environment variable"**. If this is not done, the compiler will
-not be executable from the command line. If this happens, re-run the installer
-and check the box.
-
-This executable along with others others can be found here:
-https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads.
-
-### Verifying Installation
-
-To check the version run the command `arm-none-eabi-g++ --version`. It should
-look like this:
+# Using Arm GNU Toolchain
 
 ```
-$ arm-none-eabi-g++ --version
-arm-none-eabi-g++ (Arm GNU Toolchain 11.3.Rel1) 11.3.1 20220712
-Copyright (C) 2021 Free Software Foundation, Inc.
-This is free software; see the source for copying conditions.  There is NO
-warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+[tool_requires]
+gnu-arm-embedded-toolchain/11.3.0
 ```
 
 # Usage

--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalArmCortexConan(ConanFile):
     name = "libhal-armcortex"
-    version = "0.3.5"
+    version = "0.3.6"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"
@@ -21,7 +21,7 @@ class LibhalArmCortexConan(ConanFile):
               "cortex-m1", "cortex-m3", "cortex-m4", "cortex-m4f", "cortex-m7",
               "cortex-m23", "cortex-m55", "cortex-m35p", "cortex-m33")
     settings = "compiler"
-    exports_sources = ("include/*", "linkers/*", "LICENSE")
+    exports_sources = ("include/*", "linkers/*", "LICENSE", "toolchain.cmake")
     no_copy_source = True
 
     def package_id(self):
@@ -73,6 +73,8 @@ class LibhalArmCortexConan(ConanFile):
              "include"), src=os.path.join(self.source_folder, "include"))
         copy(self, "*.ld", dst=os.path.join(self.package_folder,
              "linkers"), src=os.path.join(self.source_folder, "linkers"))
+        copy(self, "toolchain.cmake", src=self.source_folder,
+             dst=self.package_folder)
 
     def package_info(self):
         self.cpp_info.bindirs = []
@@ -82,3 +84,7 @@ class LibhalArmCortexConan(ConanFile):
         linker_path = os.path.join(self.package_folder, "linkers")
         self.cpp_info.exelinkflags = ["-L" + linker_path]
         self.cpp_info.set_property("cmake_target_name", "libhal::armcortex")
+        # Add toolchain.cmake to user_toolchain configuration info to be used
+        # by CMakeToolchain generator
+        f = os.path.join(self.package_folder, "toolchain.cmake")
+        self.conf_info.append("tools.cmake.cmaketoolchain:user_toolchain", f)

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -1,0 +1,155 @@
+# Append current directory to CMAKE_MODULE_PATH for making device specific
+# cmake modules visible
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
+# Target definition
+set(CMAKE_SYSTEM_NAME Generic)
+set(CMAKE_SYSTEM_PROCESSOR ARM)
+
+# ------------------------------------------------------------------------------
+# Set toolchain paths
+# ------------------------------------------------------------------------------
+if(NOT DEFINED TOOLCHAIN_PATH)
+  set(TOOLCHAIN_PATH "") # assume global location
+endif(NOT DEFINED TOOLCHAIN_PATH)
+
+set(TOOLCHAIN arm-none-eabi)
+
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Debug")
+endif(NOT DEFINED CMAKE_BUILD_TYPE)
+
+# Set system depended extensions
+if(WIN32)
+  set(TOOLCHAIN_EXT ".exe")
+else()
+  set(TOOLCHAIN_EXT "")
+endif()
+
+# Perform compiler test with static library
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+# ------------------------------------------------------------------------------
+# Set compiler/linker flags
+# ------------------------------------------------------------------------------
+
+# Object build options
+#
+# -O0                   No optimizations, reduce compilation time and make
+# debugging produce the expected results.
+# -mthumb               Generate thumb instructions.
+# -fno-builtin          Do not use built-in functions provided by GCC.
+# -Wall                 Print only standard warnings, for all use Wextra
+# -ffunction-sections   Place each function item into its own section in the
+# output file.
+# -fdata-sections       Place each data item into its own section in the output
+# file.
+# -fomit-frame-pointer  Omit the frame pointer in functions that don’t need one.
+# -mabi=aapcs           Defines enums to be a variable sized type.
+set(OBJECT_GEN_FLAGS "-mthumb -fno-builtin -Wall -ffunction-sections \
+    -fdata-sections -fomit-frame-pointer -fno-exceptions \
+    -fno-rtti -mabi=aapcs")
+
+set(CMAKE_C_FLAGS "${OBJECT_GEN_FLAGS} "
+  CACHE INTERNAL "C Compiler options")
+set(CMAKE_CXX_FLAGS "${OBJECT_GEN_FLAGS} "
+  CACHE INTERNAL "C++ Compiler options")
+set(CMAKE_ASM_FLAGS "${OBJECT_GEN_FLAGS} -x assembler-with-cpp "
+  CACHE INTERNAL "ASM Compiler options")
+
+# -Wl,--gc-sections     Perform the dead code elimination.
+# --specs=nano.specs    Link with newlib-nano.
+# --specs=nosys.specs   No syscalls, provide empty implementations for the
+# POSIX system calls.
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections --specs=nano.specs \
+    --specs=nosys.specs -mthumb -mabi=aapcs -Wl,-Map=${CMAKE_PROJECT_NAME}.map"
+  CACHE INTERNAL "Linker options")
+
+# ------------------------------------------------------------------------------
+# Set debug/release build configuration Options
+# ------------------------------------------------------------------------------
+
+# Options for DEBUG build
+# -Og   Enables optimizations that do not interfere with debugging.
+# -g    Produce debugging information in the operating system’s native format.
+set(CMAKE_C_FLAGS_DEBUG "-O0 -g"
+  CACHE INTERNAL "C Compiler options for debug build type")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g"
+  CACHE INTERNAL "C++ Compiler options for debug build type")
+set(CMAKE_ASM_FLAGS_DEBUG "-g"
+  CACHE INTERNAL "ASM Compiler options for debug build type")
+set(CMAKE_EXE_LINKER_FLAGS_DEBUG ""
+  CACHE INTERNAL "Linker options for debug build type")
+
+# Options for RELEASE build
+# -Os   Optimize for size. -Os enables all -O2 optimizations.
+set(CMAKE_C_FLAGS_RELEASE "-Os -g -DNDEBUG"
+  CACHE INTERNAL "C Compiler options for release build type")
+set(CMAKE_CXX_FLAGS_RELEASE "-Os -g -DNDEBUG"
+  CACHE INTERNAL "C++ Compiler options for release build type")
+set(CMAKE_ASM_FLAGS_RELEASE ""
+  CACHE INTERNAL "ASM Compiler options for release build type")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE ""
+  CACHE INTERNAL "Linker options for release build type")
+
+# ------------------------------------------------------------------------------
+# Set compilers
+# ------------------------------------------------------------------------------
+set(CMAKE_C_COMPILER ${TOOLCHAIN_PATH}${TOOLCHAIN}-gcc${TOOLCHAIN_EXT}
+  CACHE INTERNAL "C Compiler")
+set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PATH}${TOOLCHAIN}-g++${TOOLCHAIN_EXT}
+  CACHE INTERNAL "C++ Compiler")
+set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PATH}${TOOLCHAIN}-gcc${TOOLCHAIN_EXT}
+  CACHE INTERNAL "ASM Compiler")
+set(CMAKE_SIZE_UTIL ${TOOLCHAIN_PATH}${TOOLCHAIN}-size${TOOLCHAIN_EXT}
+  CACHE INTERNAL "size tool")
+set(CMAKE_OBJDUMP ${TOOLCHAIN_PATH}${TOOLCHAIN}-objdump${TOOLCHAIN_EXT}
+  CACHE INTERNAL "display various information about object files")
+set(CMAKE_OBJCOPY ${TOOLCHAIN_PATH}${TOOLCHAIN}-objcopy${TOOLCHAIN_EXT}
+  CACHE INTERNAL "utility copies the contents of an object file to another")
+set(CMAKE_FIND_ROOT_PATH ${TOOLCHAIN_PREFIX}${${TOOLCHAIN}}
+  ${CMAKE_PREFIX_PATH} ${CMAKE_BINARY_DIR})
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(CORTEX_M4F_FLAGS -mcpu=cortex-m4 -mthumb -mtpcs-frame -mtpcs-leaf-frame
+  -mfloat-abi=softfp -mfpu=fpv4-sp-d16)
+
+set(CORTEX_M4_FLAGS -mcpu=cortex-m4 -mthumb -mtpcs-frame -mtpcs-leaf-frame
+  -mfloat-abi=soft)
+
+function(arm_post_build elf_file)
+  find_program(SIZE ${CMAKE_SIZE_UTIL})
+  find_program(OBJCOPY ${CMAKE_OBJCOPY})
+  find_program(OBJDUMP ${CMAKE_OBJDUMP})
+
+  # Print executable size
+  add_custom_command(TARGET ${elf_file} POST_BUILD
+    COMMAND ${SIZE} ${CMAKE_CURRENT_BINARY_DIR}/${elf_file})
+
+  # Create hex (intel hex) file
+  add_custom_command(TARGET ${elf_file} POST_BUILD
+    COMMAND ${OBJCOPY} -O ihex ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}
+    ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}.hex)
+
+  # Create bin (binary) file
+  add_custom_command(TARGET ${elf_file} POST_BUILD
+    COMMAND ${OBJCOPY} -O binary
+    ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}
+    ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}.bin)
+
+  # Create disassembly file
+  add_custom_command(TARGET ${elf_file} POST_BUILD
+    COMMAND ${OBJDUMP} --disassemble --demangle
+    ${CMAKE_CURRENT_BINARY_DIR}/${elf_file} >
+    ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}.S)
+
+  # Create disassembly file with source information
+  add_custom_command(TARGET ${elf_file} POST_BUILD
+    COMMAND ${OBJDUMP} --all-headers --source
+    --disassemble --demangle ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}
+    > ${CMAKE_CURRENT_BINARY_DIR}/${elf_file}.lst)
+endfunction()


### PR DESCRIPTION
Removes the need for VirtualBuildEnv for getting gnu arm gcc toolchain programs. Previously found in gnu-arm-embedded-toolchain as of commit 23bfe197f6b1a98c58b3e8ac62017c89b66c3406.

The toolchain file has been updated in the following ways:

- arm_post_build() macro is now a function to prevent leaking variables to outer scope
- arm_post_build() now works without VirtualBuildEnv and without adding the gnu-arm-embedded-toolchain to the PATH variable