### PR TITLE
:zap: void return type for interrupt::disable

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalArmCortexConan(ConanFile):
     name = "libhal-armcortex"
-    version = "0.3.6"
+    version = "0.3.7"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"

--- a/include/libhal-armcortex/interrupt.hpp
+++ b/include/libhal-armcortex/interrupt.hpp
@@ -346,25 +346,25 @@ public:
     if (!m_id.default_enabled()) {
       nvic_enable_irq();
     }
-    return {};
+    return hal::success();
   }
 
   /**
    * @brief disable interrupt and set the service routine handler to "nop".
    *
-   * @return true - successfully disabled interrupt
-   * @return false - irq value is outside of the bounds of the table
+   * If the IRQ is invalid, then nothing happens.
    */
-  [[nodiscard]] status disable()
+  void disable()
   {
-    HAL_CHECK(sanity_check());
+    if (!sanity_check()) {
+      return;
+    }
 
     vector_table[m_id.vector_index()] = nop;
 
     if (!m_id.default_enabled()) {
       nvic_disable_irq();
     }
-    return {};
   }
 
   /**
@@ -408,7 +408,7 @@ private:
       return hal::new_error(invalid_irq(m_id));
     }
 
-    return {};
+    return hal::success();
   }
 
   bool vector_table_is_initialized()

--- a/include/libhal-armcortex/systick_timer.hpp
+++ b/include/libhal-armcortex/systick_timer.hpp
@@ -153,9 +153,7 @@ public:
   ~systick_timer()
   {
     stop();
-    if (!cortex_m::interrupt(event_number).disable()) {
-      std::abort();
-    }
+    cortex_m::interrupt(event_number).disable();
   }
 
 private:

--- a/tests/interrupt.test.cpp
+++ b/tests/interrupt.test.cpp
@@ -130,11 +130,9 @@ void interrupt_test()
         static_cast<uint32_t>(shifted_event_number) & 0x1F;
 
       // Exercise
-      bool success =
-        static_cast<bool>(interrupt(expected_event_number).disable());
+      interrupt(expected_event_number).disable();
 
       // Verify
-      expect(that % success);
       expect(that % &interrupt::nop ==
              interrupt::vector_table[expected_event_number]);
 
@@ -153,11 +151,9 @@ void interrupt_test()
         static_cast<uint32_t>(shifted_event_number) & 0x1F;
 
       // Exercise
-      bool success =
-        static_cast<bool>(interrupt(expected_event_number).disable());
+      interrupt(expected_event_number).disable();
 
       // Verify
-      expect(that % success);
       expect(that % &interrupt::nop ==
              interrupt::vector_table[expected_event_number]);
 
@@ -172,11 +168,9 @@ void interrupt_test()
       const auto old_nvic = *interrupt::nvic();
 
       // Exercise
-      bool success =
-        static_cast<bool>(interrupt(expected_event_number).disable());
+      interrupt(expected_event_number).disable();
 
       // Verify
-      expect(that % success);
       // Verify: That the dummy handler was added to the IVT (icer )
       expect(that % &interrupt::nop ==
              interrupt::vector_table[expected_event_number]);
@@ -195,11 +189,7 @@ void interrupt_test()
       const auto old_nvic = *interrupt::nvic();
 
       // Exercise
-      bool success =
-        static_cast<bool>(interrupt(expected_event_number).disable());
-
-      // Verify
-      expect(that % !success);
+      interrupt(expected_event_number).disable();
 
       // Verify: Nothing in the interrupt vector table should have changed
       for (const auto& interrupt_function : interrupt::vector_table) {


### PR DESCRIPTION
If this function is ever called with an incorrect irq number, simple do nothing rather than transmit an error. Disabling something that doesn't exist is the same as having done nothing. Unlike in the enable case where there is an expectation that something should have occurred.