### PR TITLE
:rocket: Launch version 1.0.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -11,7 +11,7 @@ required_conan_version = ">=1.50.0"
 
 class LibhalArmCortexConan(ConanFile):
     name = "libhal-armcortex"
-    version = "0.3.10"
+    version = "1.0.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"
@@ -40,8 +40,8 @@ class LibhalArmCortexConan(ConanFile):
         }
 
     def requirements(self):
-        self.requires("libhal/0.3.5")
-        self.requires("libhal-util/0.3.9")
+        self.requires("libhal/[^1.0.0]")
+        self.requires("libhal-util/[^1.0.0]")
 
     def validate(self):
         if self.settings.get_safe("compiler.cppstd"):

--- a/include/libhal-armcortex/dwt_counter.hpp
+++ b/include/libhal-armcortex/dwt_counter.hpp
@@ -156,14 +156,14 @@ public:
   }
 
 private:
-  result<std::uint64_t> driver_uptime() override
+  result<uptime_t> driver_uptime() override
   {
-    return m_uptime.update(dwt()->cyccnt);
+    return uptime_t{ .ticks = m_uptime.update(dwt()->cyccnt) };
   }
 
-  hertz driver_frequency() override
+  result<frequency_t> driver_frequency() override
   {
-    return m_cpu_frequency;
+    return frequency_t{ .operating_frequency = m_cpu_frequency };
   }
 
   overflow_counter<32> m_uptime{};

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -3,5 +3,5 @@
 int main()
 {
   hal::cortex_m::dwt_counter counter(1'000'000.0f);
-  return counter.uptime().value();
+  return counter.uptime().value().ticks;
 }

--- a/tests/conanfile.txt
+++ b/tests/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 boost-ext-ut/1.1.9
-libhal-armcortex/0.3.9
+libhal-armcortex/1.0.0
 
 [generators]
 CMakeToolchain

--- a/tests/dwt_counter.test.cpp
+++ b/tests/dwt_counter.test.cpp
@@ -20,37 +20,37 @@ void dwt_test()
     dwt_counter test_subject(operating_frequency);
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 0;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % 0 == count);
     }
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 17;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % 17 == count);
     }
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 1024;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % 1024 == count);
     }
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 5;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % (1ULL << 32 | 5) == count);
     }
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 4;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % (2ULL << 32 | 4) == count);
     }
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 3;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % (3ULL << 32 | 3) == count);
     }
     {
       cortex_m::dwt_counter::dwt()->cyccnt = 10;
-      auto count = test_subject.uptime().value();
+      auto count = test_subject.uptime().value().ticks;
       expect(that % (3ULL << 32 | 10) == count);
     }
   };
@@ -61,8 +61,8 @@ void dwt_test()
       constexpr auto expected_frequency = 12.0_kHz;
       cortex_m::dwt_counter::dwt()->cyccnt = 0;
       test_subject.register_cpu_frequency(expected_frequency);
-      auto count = test_subject.uptime().value();
-      auto freq = test_subject.frequency();
+      auto count = test_subject.uptime().value().ticks;
+      auto freq = test_subject.frequency().value().operating_frequency;
       expect(that % 0 == count);
       expect(that % 0.01f > std::abs(freq - expected_frequency));
     }
@@ -70,8 +70,8 @@ void dwt_test()
       constexpr auto expected_frequency = 99.0_kHz;
       cortex_m::dwt_counter::dwt()->cyccnt = 1337;
       test_subject.register_cpu_frequency(expected_frequency);
-      auto count = test_subject.uptime().value();
-      auto freq = test_subject.frequency();
+      auto count = test_subject.uptime().value().ticks;
+      auto freq = test_subject.frequency().value().operating_frequency;
       expect(that % 1337 == count);
       expect(that % 0.01f > std::abs(freq - expected_frequency));
     }
@@ -79,8 +79,8 @@ void dwt_test()
       constexpr auto expected_frequency = 154.0_kHz;
       cortex_m::dwt_counter::dwt()->cyccnt = 65'000'192;
       test_subject.register_cpu_frequency(expected_frequency);
-      auto count = test_subject.uptime().value();
-      auto freq = test_subject.frequency();
+      auto count = test_subject.uptime().value().ticks;
+      auto freq = test_subject.frequency().value().operating_frequency;
       expect(that % 65'000'192 == count);
       expect(that % 0.01f > std::abs(freq - expected_frequency));
     }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,6 +7,9 @@ set -e
 script_path="$(dirname "${BASH_SOURCE[0]}")"
 cd $script_path
 
+# Create test package first
+conan create ..
+
 # Create, if not present, the "build" directory and move into it
 mkdir -p build
 cd build


### PR DESCRIPTION
- :arrow_up: Upgrade to libhal/[^1.0.0]. Using `^` to ensure that libhal-util can work any other library with a compatible major number of libhal.
- :arrow_up: Upgrade to libhal-util/[^1.0.0]. Using `^` to ensure that libhal-util can work any other library with a compatible major number of libhal.
- :recycle: Refactor code to use latest libhal code