### PR TITLE
:bug: Change from c++20 to gnu20

### DIFF
--- a/conan/profiles/cortex-m
+++ b/conan/profiles/cortex-m
@@ -1,6 +1,6 @@
 [settings]
 compiler=gcc
-compiler.cppstd=20
+compiler.cppstd=gnu20
 compiler.libcxx=libstdc++
 compiler.version=12.2
 os=baremetal


### PR DESCRIPTION
Seeing if this provides usable prebuilt binaries. Using C++20 seems to cause conan to not recognize the standard type.