### PR TITLE
:wrench: Add compiler flags to cortex-m profile

### DIFF
--- a/conan/profiles/cortex-m
+++ b/conan/profiles/cortex-m
@@ -10,3 +10,8 @@ arch.processor={{ cpu }}
 
 [tool_requires]
 arm-gnu-toolchain/12.2.1
+
+[conf]
+tools.build:cflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}"]
+tools.build:cxxflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}"]
+tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -175,14 +175,3 @@ class libhal_arm_cortex_conan(ConanFile):
         ):
             linker_path = os.path.join(self.package_folder, "linker_scripts")
             self.cpp_info.exelinkflags.append("-L" + linker_path)
-
-            gcc_flags = [
-                f"-mcpu={ str(self.settings.arch.processor) }",
-                f"-mfloat-abi={ str(self.settings.arch.float_abi) }"
-            ]
-            linker_flags = ["--specs=nano.specs", "--specs=nosys.specs"]
-
-            self.cpp_info.cflags.extend(gcc_flags)
-            self.cpp_info.cxxflags.extend(gcc_flags)
-            self.cpp_info.exelinkflags.extend(gcc_flags)
-            self.cpp_info.exelinkflags.extend(linker_flags)

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -40,8 +40,8 @@ foreach(demo IN LISTS DEMOS)
         libhal::armcortex
         libhal::util)
 
-    target_compile_options(${current_project} PUBLIC --specs=nano.specs --specs=nosys.specs)
-    target_link_options(${current_project} PUBLIC --specs=nano.specs --specs=nosys.specs -T${CMAKE_SOURCE_DIR}/linker.ld)
+    target_link_options(${current_project} PUBLIC
+        -T${CMAKE_SOURCE_DIR}/linker.ld)
 
     arm_cortex_post_build(${current_project})
 endforeach()


### PR DESCRIPTION
These flags are required to build prebuilt binaries for device drivers. For platform libraries, the flags are delivered via the libhal-armcortex requirement. But this is a transitive requirement and will not extend to device library packages.