### PR TITLE
:technologist: Add debug info to all builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(libhal-armcortex
 
 target_include_directories(libhal-armcortex PUBLIC include)
 target_compile_features(libhal-armcortex PRIVATE cxx_std_20)
+target_compile_options(libhal-armcortex PRIVATE -g)
 
 if(DEFINED LIBHAL_GCC_CPU AND DEFINED LIBHAL_GCC_FLOAT_ABI)
   target_compile_options(libhal-armcortex PRIVATE

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_arm_cortex_conan(ConanFile):
     name = "libhal-armcortex"
-    version = "2.0.0-alpha.1"
+    version = "2.0.0-alpha.2"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"

--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -27,7 +27,7 @@ find_package(libhal-armcortex REQUIRED CONFIG)
 set(DEMOS dwt_counter)
 
 add_library(startup_code main.cpp)
-
+target_compile_options(startup_code PRIVATE -g)
 target_link_libraries(startup_code PRIVATE libhal::armcortex libhal::util)
 
 foreach(demo IN LISTS DEMOS)
@@ -36,6 +36,7 @@ foreach(demo IN LISTS DEMOS)
     add_executable(${current_project} applications/${demo}.cpp)
 
     target_compile_features(${current_project} PRIVATE cxx_std_20)
+    target_compile_options(${current_project} PRIVATE -g)
     target_link_libraries(${current_project} PRIVATE startup_code
         libhal::armcortex
         libhal::util)

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -41,7 +41,7 @@ class demos(ConanFile):
         self.tool_requires("cmake-arm-embedded/1.0.0")
 
     def requirements(self):
-        self.requires("libhal-armcortex/2.0.0-alpha.1")
+        self.requires("libhal-armcortex/2.0.0-alpha.2")
         self.requires("libhal-util/2.0.0")
 
     def build(self):


### PR DESCRIPTION
CMake only adds the `-g` debug info flag for the "Debug" build type. This makes sense for libraries deployed on a server or computer but not an embedded system. The elf file is not what is executed but the .bin or .hex file generated from it. Those generated files have all extra debug info eliminated. Because of this, each build type can have debug information without degrading performance or increasing code size. The benefit is that users can use an on chip debugger and step into this libraries APIs to inspect possible issues or hidden registers.