### PR TITLE
:bug: Copy top-of-stack & reset handler for IVT

### DIFF
--- a/src/interrupt.cpp
+++ b/src/interrupt.cpp
@@ -159,10 +159,18 @@ void interrupt::setup(std::span<interrupt_pointer> p_vector_table)
   // application.
   vector_table = p_vector_table;
 
+  // Copy the "top-of-stack" from the original vector table
+  vector_table[0] = reinterpret_cast<interrupt_pointer*>(
+    get_interrupt_vector_table_address())[0];
+
+  // Copy the "reset" handler from the original vector table
+  vector_table[1] = reinterpret_cast<interrupt_pointer*>(
+    get_interrupt_vector_table_address())[1];
+
   // Fill the interrupt handler and vector table with a function that does
   // nothing functions. Skip the first 2 which are the top of stock and reset
   // handlers.
-  std::fill(vector_table.begin(), vector_table.end(), &nop);
+  std::fill(vector_table.begin() + 2, vector_table.end(), &nop);
 
   disable_interrupts();
 


### PR DESCRIPTION
A valid top-of-stack value from the IVT is a requirement for RTOS systems to work.

Some systems may utilize the IVT's reset handler in order to manage a reset so that location must also be preserved in the IVT.