### PR TITLE
:construction_worker: Remove release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: ✅ CI
 on:
   workflow_dispatch:
   pull_request:
+  release:
+    types:
+      - published
   push:
-    tags:
-      - "*"
     branches:
       - main
   schedule:
@@ -59,23 +60,3 @@ jobs:
       profile: cortex-m4f
       upload: true
     secrets: inherit
-
-  release:
-    needs:
-      [
-        ci,
-        cortex-m0,
-        cortex-m0plus,
-        cortex-m1,
-        cortex-m3,
-        cortex-m4,
-        cortex-m4f,
-      ]
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          generate_release_notes: true


### PR DESCRIPTION
Release creation invokes upload, rather than a tag upload invoking an upload and release creation. Makes the interface more user friendly.