### PR TITLE
:sparkles: Add irq constants

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -26,7 +26,7 @@ required_conan_version = ">=1.50.0"
 
 class libhal_arm_cortex_conan(ConanFile):
     name = "libhal-armcortex"
-    version = "2.0.3"
+    version = "2.1.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"

--- a/include/libhal-armcortex/interrupt.hpp
+++ b/include/libhal-armcortex/interrupt.hpp
@@ -25,6 +25,32 @@ namespace hal::cortex_m {
 using interrupt_pointer = void (*)();
 
 /**
+ * @brief IRQ numbers for core processor interrupts
+ *
+ */
+enum class irq
+{
+  top_of_stack = 0,
+  reset = 1,
+  /// @brief  non-maskable interrupt
+  nmi = 2,
+  hard_fault = 3,
+  memory_management_fault = 4,
+  bus_fault = 5,
+  usage_fault = 6,
+  reserve7 = 7,
+  reserve8 = 8,
+  reserve9 = 9,
+  reserve10 = 10,
+  /// @brief Software initiated interrupt
+  sv_call = 11,
+  reserve12 = 12,
+  reserve13 = 13,
+  pend_sv = 14,
+  systick = 15,
+};
+
+/**
  * @brief Cortex M series interrupt controller
  *
  */


### PR DESCRIPTION
These constants can make it easier to ensure that the correct interrupt handler was set to the correct interrupt handler.