### PR TITLE
:sparkles: Add wait_for_interrupt/event APIs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -21,12 +21,12 @@ from conan.tools.build import check_min_cppstd
 import os
 
 
-required_conan_version = ">=1.50.0"
+required_conan_version = ">=2.0.6"
 
 
 class libhal_arm_cortex_conan(ConanFile):
     name = "libhal-armcortex"
-    version = "2.1.0"
+    version = "2.2.0"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-armcortex"

--- a/include/libhal-armcortex/system_control.hpp
+++ b/include/libhal-armcortex/system_control.hpp
@@ -73,4 +73,20 @@ void* get_interrupt_vector_table_address();
  *
  */
 void reset();
+
+/**
+ * @brief Executes WFI instruction
+ *
+ * The WFI instruction stops the CPU, reducing power, and wakes up on interrupt.
+ *
+ */
+void wait_for_interrupt();
+
+/**
+ * @brief Executes WFE instruction
+ *
+ * The WFE instruction stops the CPU, reducing power, and wakes up on event.
+ *
+ */
+void wait_for_event();
 }  // namespace hal::cortex_m

--- a/src/system_controller.cpp
+++ b/src/system_controller.cpp
@@ -49,4 +49,18 @@ void reset()
   // System reset is asynchronous, so the code needs to wait.
   hal::halt();
 }
+
+void wait_for_interrupt()
+{
+#if defined(__arm__)
+  asm volatile("wfi");
+#endif
+}
+
+void wait_for_event()
+{
+#if defined(__arm__)
+  asm volatile("wfe");
+#endif
+}
 }  // namespace hal::cortex_m


### PR DESCRIPTION
wait_for_interrupt/event APIs allow the system to go into various sleep modes dictated by the MCU or the ARM core registers.