### PR TITLE
:sparkles: Add picolibc.specs into profiles

### DIFF
--- a/conan/profiles/thumbv6
+++ b/conan/profiles/thumbv6
@@ -8,9 +8,9 @@ arch=thumbv6
 arch.processor={{ cpu }}
 
 [tool_requires]
-arm-gnu-toolchain/12.2.1
+arm-gnu-toolchain/12.2.1#b7f80575b375a5e677525f70c1761dda
 
 [conf]
 tools.build:cflags=["-mfloat-abi=soft", "-mcpu={{ cpu }}", "-mthumb", "-ffunction-sections", "-fdata-sections"]
 tools.build:cxxflags=["-mfloat-abi=soft", "-mcpu={{ cpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]
-tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "-mfloat-abi=soft", "-mcpu={{ cpu }}", "-mthumb", "-fno-exceptions", "-fno-rtti", "-Wl,--gc-sections", "-Wl,--print-memory-usage"]
+tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "--specs=picolibc.specs", "-mfloat-abi=soft", "-mcpu={{ cpu }}", "-mthumb", "-fno-exceptions", "-fno-rtti", "-Wl,--gc-sections", "-Wl,--print-memory-usage"]

--- a/conan/profiles/thumbv7
+++ b/conan/profiles/thumbv7
@@ -10,9 +10,9 @@ arch.fpu={{ fpu }}
 arch.processor={{ cpu }}
 
 [tool_requires]
-arm-gnu-toolchain/12.2.1
+arm-gnu-toolchain/12.2.1#b7f80575b375a5e677525f70c1761dda
 
 [conf]
 tools.build:cflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mfpu={{ fpu }}", "-mthumb", "-ffunction-sections", "-fdata-sections"]
 tools.build:cxxflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mfpu={{ fpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]
-tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mfpu={{ fpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]
+tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "--specs=picolibc.specs", "-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mfpu={{ fpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]

--- a/conan/profiles/thumbv8
+++ b/conan/profiles/thumbv8
@@ -9,9 +9,9 @@ arch.float_abi={{ float_abi }}
 arch.processor={{ cpu }}
 
 [tool_requires]
-arm-gnu-toolchain/12.2.1
+arm-gnu-toolchain/12.2.1#b7f80575b375a5e677525f70c1761dda
 
 [conf]
 tools.build:cflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mthumb", "-ffunction-sections", "-fdata-sections"]
 tools.build:cxxflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]
-tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]
+tools.build:exelinkflags=["--specs=nano.specs", "--specs=nosys.specs", "--specs=picolibc.specs", "-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-fno-exceptions", "-fno-rtti", "-mthumb", "-ffunction-sections", "-fdata-sections"]


### PR DESCRIPTION
This will cause all executables built using the libhal-armcortex profiles to automatically use the picolibc.specs which will reduce code size significantly.