### PR TITLE
:pushpin: Lock arm-gnu-toolchain for thumb profiles

### DIFF
--- a/conan/profiles/thumbv6
+++ b/conan/profiles/thumbv6
@@ -8,7 +8,7 @@ arch=thumbv6
 arch.processor={{ cpu }}
 
 [tool_requires]
-arm-gnu-toolchain/12.2.1
+arm-gnu-toolchain/12.2.1#8d6c7a2e49b05790f0cf890398cfe760
 
 [conf]
 tools.build:cflags=["-mfloat-abi=soft", "-mcpu={{ cpu }}", "-mthumb", "-ffunction-sections", "-fdata-sections"]

--- a/conan/profiles/thumbv7
+++ b/conan/profiles/thumbv7
@@ -10,7 +10,7 @@ arch.fpu={{ fpu }}
 arch.processor={{ cpu }}
 
 [tool_requires]
-arm-gnu-toolchain/12.2.1
+arm-gnu-toolchain/12.2.1#8d6c7a2e49b05790f0cf890398cfe760
 
 [conf]
 tools.build:cflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mfpu={{ fpu }}", "-mthumb", "-ffunction-sections", "-fdata-sections"]

--- a/conan/profiles/thumbv8
+++ b/conan/profiles/thumbv8
@@ -9,7 +9,7 @@ arch.float_abi={{ float_abi }}
 arch.processor={{ cpu }}
 
 [tool_requires]
-arm-gnu-toolchain/12.2.1
+arm-gnu-toolchain/12.2.1#8d6c7a2e49b05790f0cf890398cfe760
 
 [conf]
 tools.build:cflags=["-mfloat-abi={{ float_abi }}", "-mcpu={{ cpu }}", "-mthumb", "-ffunction-sections", "-fdata-sections"]


### PR DESCRIPTION
The cortex and thumb profiles will be deprecated soon, but for those still using the old system, the revision for the profiles must be locked to a version that automatically installs picolibc for you which is 8d6c7a2e49b05790f0cf890398cfe760.

When picolibc is split from arm-gnu-toolchain, the new revision will break users of the old profiles. This prevents this.