### PR TITLE
:technologist: Require libhal-exceptions & prebuilt-picolibc

### DIFF
--- a/.github/workflows/3.0.1.yml
+++ b/.github/workflows/3.0.1.yml
@@ -1,0 +1,11 @@
+name: 🚀 Release 3.0.1
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-version.yml
+    with:
+      version: 3.0.1
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-      # Remove before merging with main
-      - exceptions
   schedule:
     - cron: "0 12 * * 0"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -33,12 +33,30 @@ class libhal_arm_cortex_conan(ConanFile):
               "cortex-m23", "cortex-m55", "cortex-m35p", "cortex-m33")
     settings = "compiler", "build_type", "os", "arch"
 
-    python_requires = "libhal-bootstrap/[^0.0.4]"
+    python_requires = "libhal-bootstrap/[^0.0.6]"
     python_requires_extend = "libhal-bootstrap.library"
+
+    options = {
+        "use_libhal_exceptions": [True, False],
+        "use_picolibc": [True, False],
+    }
+
+    default_options = {
+        "use_libhal_exceptions": True,
+        "use_picolibc": True,
+    }
 
     def requirements(self):
         bootstrap = self.python_requires["libhal-bootstrap"]
         bootstrap.module.add_library_requirements(self)
+
+        if self.settings.os == "baremetal" and self.settings.compiler == "gcc":
+            if self.options.use_libhal_exceptions:
+                self.requires(
+                    "libhal-exceptions/[^0.0.2]", transitive_headers=True)
+            if self.options.use_picolibc:
+                compiler_version = str(self.settings.compiler.version)
+                self.requires("prebuilt-picolibc/" + compiler_version)
 
     def package_info(self):
         self.cpp_info.libs = ["libhal-armcortex"]
@@ -52,3 +70,7 @@ class libhal_arm_cortex_conan(ConanFile):
         ):
             linker_path = os.path.join(self.package_folder, "linker_scripts")
             self.cpp_info.exelinkflags.append("-L" + linker_path)
+
+    def package_id(self):
+        del self.info.options.use_picolibc
+        del self.info.options.use_libhal_exceptions


### PR DESCRIPTION
All libhal Arm Cortex M processors will need exception handling. picolibc provides that along with other benefits. libhal-exceptions provides the capability to set your exception allocator, terminate handler and soon your exception runtime implementation. All drivers should have this linked in as a default, rather than having to manage this themselves. Options are provided such as `use_libhal_exceptions` and `use_picolibc` to allow the user to disable these requirements if needed.

libhal-bootstrap will no longer need to require these dependencies themselves. Now it just needs to map the profile name to the correct platform and all of the required packages should get linked in.

This also allows demos and applications to link in the arm cortex platform packages without having to provide logic to link the two other dependencies.