### PR TITLE
:boom: Refactor interrupt APIs

### DIFF
--- a/.github/workflows/5.0.0.yml
+++ b/.github/workflows/5.0.0.yml
@@ -1,0 +1,11 @@
+name: 🚀 Release 5.0.0
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-version.yml
+    with:
+      version: 5.0.0
+    secrets: inherit

--- a/include/libhal-armcortex/interrupt.hpp
+++ b/include/libhal-armcortex/interrupt.hpp
@@ -16,262 +16,310 @@
 
 #include <array>
 #include <span>
-#include <utility>
+#include <type_traits>
 
 #include <libhal/error.hpp>
 
 namespace hal::cortex_m {
 /// Used specifically for defining an interrupt vector table of addresses.
 using interrupt_pointer = void (*)();
+using irq_t = std::int16_t;
+
+/**
+ * @ingroup Enum
+ * @brief concept for enumeration types
+ *
+ * @tparam T - enum type
+ */
+template<typename T>
+concept irq_enum =
+  std::is_enum_v<T> && std::is_same_v<std::underlying_type_t<T>, irq_t>;
 
 /**
  * @brief IRQ numbers for core processor interrupts
  *
+ * All core IRQs are enabled by default.
  */
-enum class irq
+enum class irq : irq_t
 {
-  top_of_stack = 0,
-  reset = 1,
-  /// @brief  non-maskable interrupt
-  nmi = 2,
-  hard_fault = 3,
-  memory_management_fault = 4,
-  bus_fault = 5,
-  usage_fault = 6,
-  reserve7 = 7,
-  reserve8 = 8,
-  reserve9 = 9,
-  reserve10 = 10,
-  /// @brief Software initiated interrupt
-  sv_call = 11,
-  reserve12 = 12,
-  reserve13 = 13,
-  pend_sv = 14,
-  systick = 15,
+  top_of_stack = -16,
+  reset = -15,
+  non_maskable_interrupt = -14,
+  hard_fault = -13,
+  memory_management_fault = -12,
+  bus_fault = -11,
+  usage_fault = -10,
+  reserve7 = -9,
+  reserve8 = -8,
+  reserve9 = -7,
+  reserve10 = -6,
+  software_call = -5,
+  reserve12 = -4,
+  reserve13 = -3,
+  pend_sv = -2,
+  systick = -1,
 };
+
+constexpr auto core_interrupts = static_cast<irq_t>(irq::top_of_stack);
 
 /**
- * @brief Cortex M series interrupt controller
+ * @brief A default interrupt handler that loops forever
  *
  */
-class interrupt
+void default_interrupt_handler();
+
+/**
+ * @brief Default hard fault handler
+ *
+ * Used by developers in debug mode to see if they landed in the default hard
+ * fault handler.
+ *
+ */
+void hard_fault_handler();
+
+/**
+ * @brief Default memory management fault handler
+ *
+ * Used by developers in debug mode to see if they landed in the default memory
+ * management fault handler.
+ *
+ */
+void memory_management_fault_handler();
+
+/**
+ * @brief Default bus fault handler
+ *
+ * Used by developers in debug mode to see if they landed in the default bus
+ * fault handler.
+ *
+ */
+void bus_fault_handler();
+
+/**
+ * @brief Default usage fault handler
+ *
+ * Used by developers in debug mode to see if they landed in the default usage
+ * fault handler.
+ *
+ */
+void usage_fault_handler();
+
+/**
+ * @brief Sets the interrupt vector table back to a form where it can be
+ * initialized again().
+ *
+ * Recommended to never call this function in your application. If it is called,
+ * it should be well documented why this choice was necessary.
+ *
+ * Will clear all pending interrupts and sets the internal state to
+ * uninitialized. This call is dangerous and should only be done before any
+ * drivers depend on their interrupts to function.
+ *
+ */
+void revert_interrupt_vector_table();
+
+/**
+ * @brief Initialize the interrupt vector table
+ *
+ * Using this function directly is not recommended. Use the templated version of
+ * this in drivers and in application code. Only use this if you need to control
+ * precisely where the interrupt vector table is located.
+ *
+ * If the input vector table has the same address as the previous vector table,
+ * then this function does nothing.
+ *
+ * This function does the following:
+ *
+ * - Sets the default for hard_fault to `hard_fault_handler`
+ * - Sets the default for memory_management_fault to
+ *   `memory_management_fault_handler`
+ * - Sets the default for bus_fault to `bus_fault_handler`
+ * - Sets the default for usage_fault to `usage_fault_handler`
+ * - Sets the default for everything else to `nop`
+ * - Assign a global vector_table span to the the passed vector table.
+ * - Relocates the system's interrupt vector table away from the hard coded
+ *   vector table in ROM/Flash memory to the table passed in.
+ *
+ * All default functions contain an infinite loop and it is encouraged to swap
+ * these out if you plan to use the interrupts.
+ *
+ * @param p_vector_table - must have length > 16 to accommodate the core
+ * interrupts.
+ */
+void initialize_interrupts(std::span<interrupt_pointer> p_vector_table);
+
+/**
+ * @brief Initializes the interrupt vector table.
+ *
+ * This template function does the following:
+ * - Statically allocates a 512-byte aligned an interrupt vector table the
+ *   size of max_possible_irq.
+ * - Calls the initialize_interrupts function with the array.
+ *
+ * Internally, this function checks if it has been called before and will
+ * simply return early if so. Making this function safe to call multiple times
+ * so long as the max_possible_irq template parameter is the same with each
+ * invocation.
+ *
+ * Calling this function with differing max_possible_irq values will result in
+ * multiple statically allocated interrupt vector tables, which will simply
+ * waste space in RAM. Only the first call is used as the IVT.
+ *
+ * @tparam max_possible_irq - the number of interrupts available for this system
+ */
+template<irq_t max_possible_irq>
+void initialize_interrupts()
 {
-public:
-  /// The core interrupts that all cortex m3, m4, m7 processors have
-  static constexpr size_t core_interrupts = 16;
+  static_assert(max_possible_irq > 0,
+                "Cannot initialize interrupts using a negative number. Please "
+                "supply a number above 0.");
 
-  /**
-   * @brief represents an interrupt request number along with helper functions
-   * for setting up the interrupt controller registers.
-   *
-   */
-  class exception_number
-  {
-  public:
-    /**
-     * @brief construct an exception_number from an int
-     *
-     * @param p_id - interrupt request number. If this value is beyond the
-     * bounds of the interrupt vector table, meaning it is an invalid exception
-     * number, then all operations will do nothing.
-     */
-    constexpr exception_number(std::uint16_t p_id)
-      : m_id(p_id)
-    {
-    }
+  // Statically allocate a buffer of vectors to be used as the new IVT.
+  constexpr size_t total_vector_count = max_possible_irq - core_interrupts;
 
-    constexpr exception_number(exception_number& p_id) = default;
-    constexpr exception_number& operator=(exception_number& p_id) = default;
+  alignas(512) static std::array<interrupt_pointer, total_vector_count>
+    vector_buffer{};
 
-    /**
-     * @brief Bits 5 and above represent which 32-bit word in the iser and icer
-     * arrays IRQs enable bit resides.
-     *
-     */
-    static constexpr uint32_t index_position = 5;
+  initialize_interrupts(vector_buffer);
+}
 
-    /**
-     * @brief Lower 5 bits indicate which bit within the 32-bit word is the
-     * enable bit.
-     *
-     */
-    static constexpr uint32_t enable_mask_code = 0x1F;
+/**
+ * @brief Initializes the interrupt vector table.
+ *
+ * Performs the same work as:
+ * template<size_t vector_count> initialize_interrupts(),
+ * but accepts an enumeration class object.
+ *
+ * @tparam enum_vector_count - this parameter should always be set to the
+ * `hal::platform::irq::max`.
+ */
+template<irq_enum auto max_possible_irq>
+inline void initialize_interrupts()
+{
+  initialize_interrupts<static_cast<irq_t>(max_possible_irq)>();
+}
 
-    /**
-     * @brief Determines if the irq is within the range of ARM
-     *
-     * @return true - irq is enabled by default
-     * @return false - irq must be enabled to work
-     */
-    [[nodiscard]] constexpr bool default_enabled() const
-    {
-      return m_id < core_interrupts;
-    }
+/**
+ * @brief Returns true if the interrupt vector table has been initialized
+ *
+ * This API should NOT be called by platform peripheral drivers. Those drivers
+ * should call `initialize_interrupts<irq::max>()`. That API will do the check
+ * for you and will either return early if interrupts are already enabled. There
+ * is no reason to call this API directly then call
+ * `initialize_interrupts<irq::max>()`. That is unecessary cycles.
+ *
+ * This API should be used by cortex m drivers like systick, which cannot know
+ * the size of the interrupt vector table as it is different for each
+ * microcontroller.
+ *
+ * @return true - interrupt vector table is initialized
+ * @return false - interrupt vector table is not initialized
+ */
+bool interrupt_vector_table_initialized();
 
-    [[nodiscard]] constexpr std::uint32_t to_irq_number() const
-    {
-      return static_cast<std::uint32_t>(m_id - core_interrupts);
-    }
+/**
+ * @brief Disable all interrupts
+ *
+ */
+void disable_all_interrupts();
 
-    /**
-     * @brief the enable bit for this interrupt resides within one of the 32-bit
-     * registers within the "iser" and "icer" arrays. This function will return
-     * the index of which 32-bit register contains the enable bit.
-     *
-     * @return constexpr std::uint32_t - array index
-     */
-    [[nodiscard]] constexpr std::uint32_t register_index() const
-    {
-      return to_irq_number() >> index_position;
-    }
+/**
+ * @brief Re-enable all interrupts
+ *
+ */
+void enable_all_interrupts();
 
-    /**
-     * @brief return a mask with a 1 bit in the enable position for this
-     * exception_number.
-     *
-     * @return constexpr std::uint32_t - enable mask
-     */
-    [[nodiscard]] constexpr std::uint32_t enable_mask() const
-    {
-      return 1U << (to_irq_number() & enable_mask_code);
-    }
+/**
+ * @brief Get a reference to interrupt vector table object
+ *
+ * @return const std::span<interrupt_pointer> - interrupt vector table
+ */
+const std::span<interrupt_pointer> get_vector_table();
 
-    /**
-     * @brief Provides the index within the IVT
-     *
-     * @return constexpr size_t - the index position
-     */
-    [[nodiscard]] constexpr size_t vector_index() const
-    {
-      return m_id;
-    }
+/**
+ * @brief Enable interrupt and set the service routine handler.
+ *
+ * If the irq is not valid, meaning it is outside of the range of the interrupt
+ * vector table, then nothing happens.
+ *
+ * Using this with a core cortex-m interrupt will assign its handler.
+ *
+ * @param p_irq - irq to enable. If the value is beyond the range of the
+ * interrupt vector table, then this function does nothing.
+ * @param p_handler - the interrupt service routine handler to be executed
+ * when the hardware interrupt is fired.
+ */
+void enable_interrupt(irq_t p_irq, interrupt_pointer p_handler);
 
-    /**
-     * @brief determines if the irq is within bounds of the interrupt vector
-     * table.
-     *
-     * @return true - is a valid interrupt for this system
-     * @return false - this interrupt is beyond the range of valid interrupts
-     */
-    [[nodiscard]] bool is_valid() const
-    {
-      return m_id < get_vector_table().size();
-    }
+/**
+ * @brief Enable interrupt and set the service routine handler.
+ *
+ * Performs the same work as `enable_interrupt` using the `irq_t` type, but
+ * allows enum class types to be passed.
+ *
+ * @param p_irq - enumeration typed irq number
+ * @param p_handler - interrupt handler
+ */
+inline void enable_interrupt(irq_enum auto p_irq, interrupt_pointer p_handler)
+{
+  enable_interrupt(static_cast<irq_t>(p_irq), p_handler);
+}
 
-    /**
-     * @return constexpr std::uint16_t - the interrupt request number
-     */
-    [[nodiscard]] constexpr std::uint16_t get_event_number()
-    {
-      return m_id;
-    }
+/**
+ * @brief disable interrupt and set the service routine handler to their
+ * default.
+ *
+ * This function does nothing if the vector table has not yet been initialized.
+ *
+ * @param p_irq - irq to disable, if the value is below 0 or out of range then
+ * this function does nothing.
+ */
+void disable_interrupt(irq_t p_irq);
 
-  private:
-    std::uint16_t m_id = 0;
-  };
+/**
+ * @brief Disable interrupt and set the service routine handler.
+ *
+ * Performs the same work as `disable_interrupt` using the `irq_t` type, but
+ * allows enum class types to be passed.
+ *
+ * @param p_irq - enumeration typed irq number
+ */
+inline void disable_interrupt(irq_enum auto p_irq)
+{
+  disable_interrupt(static_cast<irq_t>(p_irq));
+}
 
-  /// Place holder interrupt that performs no work
-  static void nop();
+/**
+ * @brief determine if a particular handler has been put into the interrupt
+ * vector table.
+ *
+ * Generally used by unit testing code.
+ *
+ * @param p_irq - irq to check
+ * @param p_handler - the handler to check against. The address of the handler
+ * must match what is in the interrupt vector table.
+ * @return true - the handler is equal to the handler in the table
+ * @return false - the handler is not at this index in the table or p_irq is not
+ * valid.
+ */
+[[nodiscard]] bool verify_vector_enabled(irq_t p_irq,
+                                         interrupt_pointer p_handler);
 
-  /**
-   * @brief Initializes the interrupt vector table.
-   *
-   * This template function does the following:
-   * - Statically allocates a 512-byte aligned an interrupt vector table the
-   *   size of VectorCount.
-   * - Set the default handlers for all interrupt vectors to the "nop" function
-   *   which does nothing
-   * - Set vector_table span to the statically allocated vector table.
-   * - Finally it relocates the system's interrupt vector table away from the
-   *   hard coded vector table in ROM/Flash memory to the statically allocated
-   *   table in RAM.
-   *
-   * Internally, this function checks if it has been called before and will
-   * simply return early if so. Making this function safe to call multiple times
-   * so long as the VectorCount template parameter is the same with each
-   * invocation.
-   *
-   * Calling this function with differing VectorCount values will result in
-   * multiple statically allocated interrupt vector tables, which will simply
-   * waste space in RAM. Only the first call is used as the IVT.
-   *
-   * @tparam VectorCount - the number of interrupts available for this system
-   */
-  template<size_t VectorCount>
-  static void initialize()
-  {
-    // Statically allocate a buffer of vectors to be used as the new IVT.
-    static constexpr size_t total_vector_count = VectorCount + core_interrupts;
-    alignas(512) static std::array<interrupt_pointer, total_vector_count>
-      vector_buffer{};
-    setup(vector_buffer);
-  }
-
-  /**
-   * @brief Reinitialize vector table
-   *
-   * Will reset the entries of the vector table. Careful to not use this after
-   * any drivers have already put entries on to the vector table. This will also
-   * disable all interrupts currently enabled on the system.
-   *
-   * @tparam VectorCount - the number of interrupts available for this system
-   */
-  template<size_t VectorCount>
-  static void reinitialize()
-  {
-    reset();
-    initialize<VectorCount>();
-  }
-
-  /**
-   * @brief Get a reference to interrupt vector table object
-   *
-   * @return const std::span<interrupt_pointer>  - interrupt vector table
-   */
-  static const std::span<interrupt_pointer> get_vector_table();
-
-  static void disable_interrupts();
-
-  static void enable_interrupts();
-
-  /**
-   * @brief Construct a new interrupt object
-   *
-   * @param p_id - interrupt to configure
-   */
-  explicit interrupt(exception_number p_id);
-
-  /**
-   * @brief enable interrupt and set the service routine handler.
-   *
-   * @param p_handler - the interrupt service routine handler to be executed
-   * when the hardware interrupt is fired.
-   */
-  void enable(interrupt_pointer p_handler);
-
-  /**
-   * @brief disable interrupt and set the service routine handler to "nop".
-   *
-   * If the IRQ is invalid, then nothing happens.
-   */
-  void disable();
-
-  /**
-   * @brief determine if a particular handler has been put into the interrupt
-   * vector table.
-   *
-   * Generally used by unit testing code.
-   *
-   * @param p_handler - the handler to check against
-   * @return true - the handler is equal to the handler in the table
-   * @return false -  the handler is not at this index in the table
-   */
-  [[nodiscard]] bool verify_vector_enabled(interrupt_pointer p_handler);
-
-private:
-  static void reset();
-  static void setup(std::span<interrupt_pointer> p_vector_table);
-
-  exception_number m_id;
-};
+/**
+ * @brief determine if a particular handler has been put into the interrupt
+ * vector table.
+ *
+ * Generally used by unit testing code.
+ *
+ * @param p_irq - irq to check
+ * @param p_handler - the handler to check against
+ * @return true - the handler is equal to the handler in the table
+ * @return false - the handler is not at this index in the table or p_irq is not
+ * valid.
+ */
+[[nodiscard]] inline bool verify_vector_enabled(irq_enum auto p_irq,
+                                                interrupt_pointer p_handler)
+{
+  return verify_vector_enabled(static_cast<irq_t>(p_irq), p_handler);
+}
 }  // namespace hal::cortex_m

--- a/include/libhal-armcortex/systick_timer.hpp
+++ b/include/libhal-armcortex/systick_timer.hpp
@@ -51,6 +51,8 @@ public:
    *
    * @param p_frequency - the clock source's frequency
    * @param p_source - the source of the clock to the systick timer
+   * @throws hal::operation_not_permitted - thrown when the precondition to
+   * initialize the interrupt vector table before constructing this object.
    */
   systick_timer(hertz p_frequency,
                 clock_source p_source = clock_source::processor);

--- a/src/interrupt_reg.hpp
+++ b/src/interrupt_reg.hpp
@@ -53,4 +53,7 @@ struct nvic_register_t
 inline constexpr intptr_t nvic_address = 0xE000'E100UL;
 
 inline auto* nvic = reinterpret_cast<nvic_register_t*>(nvic_address);
+
+/// Place holder interrupt that performs no work
+void nop();
 }  // namespace hal::cortex_m

--- a/tests/helper.hpp
+++ b/tests/helper.hpp
@@ -1,5 +1,14 @@
 #pragma once
 
+#include <algorithm>
+#include <array>
+
+#include <libhal-armcortex/interrupt.hpp>
+#include <libhal/units.hpp>
+
+#include "interrupt_reg.hpp"
+#include "system_controller_reg.hpp"
+
 namespace hal::cortex_m {
 template<typename T>
 class stub_out_registers
@@ -11,17 +20,75 @@ public:
     , m_stub{}
   {
     m_original = *m_register_pointer;
-    *m_register_pointer = &m_stub;
+    *m_register_pointer = reinterpret_cast<T*>(m_stub.data());
+  }
+
+  stub_out_registers& operator=(const stub_out_registers&) = delete;
+  stub_out_registers(const stub_out_registers&) = delete;
+  stub_out_registers& operator=(stub_out_registers&& p_other) noexcept
+  {
+    m_register_pointer = p_other.m_register_pointer;
+    m_original = p_other.m_original;
+
+    std::copy(p_other.m_stub.begin(), p_other.m_stub.end(), m_stub.begin());
+
+    // Point the global register pointer to the new object's moved stub
+    *m_register_pointer = reinterpret_cast<T*>(m_stub.data());
+    p_other.m_moved = true;
+
+    return *this;
+  }
+
+  stub_out_registers(stub_out_registers&& p_other) noexcept
+  {
+    *this = std::move(p_other);
   }
 
   ~stub_out_registers()
   {
-    *m_register_pointer = m_original;
+    if (not m_moved) {
+      *m_register_pointer = m_original;
+    }
   }
 
 private:
   T** m_register_pointer;
   T* m_original;
-  T m_stub;
+  std::array<hal::byte, sizeof(T)> m_stub;
+  bool m_moved = false;
 };
+
+inline void fake_top_of_stack()
+{
+  while (true) {
+    continue;
+  }
+}
+
+inline void fake_reset_handler()
+{
+  while (true) {
+    continue;
+  }
+}
+
+[[nodiscard]] inline auto setup_interrupts_for_unit_testing()
+{
+  static std::array<interrupt_pointer, 2> original_ivt{ fake_top_of_stack,
+                                                        fake_reset_handler };
+  auto stub_out_nvic = stub_out_registers(&nvic);
+  auto stub_out_scb = stub_out_registers(&scb);
+  scb->vtor = reinterpret_cast<std::intptr_t>(original_ivt.data());
+
+  struct type_t
+  {
+    decltype(stub_out_nvic) remember_nvic;
+    decltype(stub_out_scb) remember_scb;
+  };
+
+  return type_t{
+    .remember_nvic = std::move(stub_out_nvic),
+    .remember_scb = std::move(stub_out_scb),
+  };
+}
 }  // namespace hal::cortex_m

--- a/tests/interrupt.test.cpp
+++ b/tests/interrupt.test.cpp
@@ -17,158 +17,203 @@
 #include <libhal-armcortex/system_control.hpp>
 
 #include "helper.hpp"
-#include "interrupt_reg.hpp"
-#include "system_controller_reg.hpp"
 
 #include <boost/ut.hpp>
+#include <libhal-util/enum.hpp>
 
 namespace hal::cortex_m {
+
 namespace {
-void top_of_stack()
+
+enum class my_irq : irq_t
 {
+  uart0 = 55,
+  spi7 = 63,
+  max,
+};
 }
-void reset_handler()
-{
-}
-}  // namespace
 
 void interrupt_test()
 {
   using namespace boost::ut;
 
-  static constexpr size_t expected_interrupt_count = 42;
+  auto saved_registers = setup_interrupts_for_unit_testing();
 
-  std::array<interrupt_pointer, 2> original_ivt{ top_of_stack, reset_handler };
-  auto stub_out_nvic = stub_out_registers(&nvic);
-  auto stub_out_scb = stub_out_registers(&scb);
+  expect(that % hal::value(irq::top_of_stack) == core_interrupts);
 
-  scb->vtor = reinterpret_cast<std::intptr_t>(original_ivt.data());
-
-  expect(that % 16 == interrupt::core_interrupts);
-
-  should("interrupt::initialize()") = [&] {
+  should("initialize_interrupt()") = [&] {
     // Setup
-    expect(that % nullptr == interrupt::get_vector_table().data());
-    expect(that % 0 == interrupt::get_vector_table().size());
+    expect(that % nullptr == get_vector_table().data());
+    expect(that % 0 == get_vector_table().size());
 
     // Exercise
-    interrupt::initialize<expected_interrupt_count>();
+    initialize_interrupts<my_irq::max>();
 
-    auto pointer =
-      reinterpret_cast<intptr_t>(interrupt::get_vector_table().data());
+    auto pointer = reinterpret_cast<intptr_t>(get_vector_table().data());
 
     // Verify
-    expect(that % nullptr != interrupt::get_vector_table().data());
-    expect(that % (expected_interrupt_count + interrupt::core_interrupts) ==
-           interrupt::get_vector_table().size());
-    expect(that % pointer == scb->vtor);
+    expect(that % nullptr != get_vector_table().data());
+    expect(that % static_cast<std::size_t>(my_irq::max) ==
+           get_vector_table().size());
+    expect(that % (pointer + (sizeof(std::uintptr_t) * core_interrupts)) ==
+           scb->vtor);
 
     // Verify: Nothing in the interrupt vector table should have changed
-    auto top_of_stack_expected = reinterpret_cast<void*>(top_of_stack);
-    auto reset_handler_expected = reinterpret_cast<void*>(reset_handler);
+    auto* top_of_stack_expected = reinterpret_cast<void*>(fake_top_of_stack);
+    auto* reset_handler_expected = reinterpret_cast<void*>(fake_reset_handler);
 
-    auto ivt_0 = interrupt::get_vector_table()[0];
-    auto ivt_1 = interrupt::get_vector_table()[1];
+    auto ivt_0 = get_vector_table()[-16];
+    auto ivt_1 = get_vector_table()[-15];
     auto top_of_stack_actual = reinterpret_cast<void*>(ivt_0);
     auto reset_handler_actual = reinterpret_cast<void*>(ivt_1);
 
     expect(that % top_of_stack_expected == top_of_stack_actual);
     expect(that % reset_handler_expected == reset_handler_actual);
 
-    for (const auto interrupt_function :
-         interrupt::get_vector_table().subspan(2)) {
-      auto nop_address = reinterpret_cast<void*>(&interrupt::nop);
+    for (const auto interrupt_function : get_vector_table().subspan(2)) {
+      auto default_interrupt_handler_address =
+        reinterpret_cast<void*>(&default_interrupt_handler);
       auto function_address = reinterpret_cast<void*>(interrupt_function);
-      expect(that % nop_address == function_address);
+      expect(that % default_interrupt_handler_address == function_address);
     }
   };
 
-  should("interrupt::enable()") = [&] {
-    interrupt_pointer dummy_handler = []() {};
+  should("enable_interrupt()") = [&] {
+    interrupt_pointer dummy_handler = +[]() {};
 
-    should("interrupt::enable(21)") = [&]() {
+    should("enable_interrupt(21)") = [&]() {
       // Setup
-      static constexpr std::uint16_t expected_event_number = 21;
-      static constexpr std::uint16_t shifted_event_number =
-        (expected_event_number - interrupt::core_interrupts);
-      unsigned index = shifted_event_number >> 5;
-      unsigned bit_position = shifted_event_number & 0x1F;
+      static constexpr std::uint16_t event_number = 21;
+      unsigned index = event_number >> 5;
+      unsigned bit_position = event_number & 0x1F;
 
       // Exercise
-      interrupt(expected_event_number).enable(dummy_handler);
+      enable_interrupt(event_number, dummy_handler);
 
       // Verify
-      expect(that % dummy_handler ==
-             interrupt::get_vector_table()[expected_event_number]);
-      std::uint32_t iser = (1U << bit_position) & nvic->iser.at(index);
-      expect(that % (1 << shifted_event_number) == iser);
+      expect(verify_vector_enabled(event_number, dummy_handler))
+        << "event number " << event_number
+        << " did not have the appropriate handler (" << &dummy_handler
+        << ") installed";
+      std::uint32_t iser = (1U << bit_position) | nvic->iser.at(index);
+      interrupt_pointer expected_handler = dummy_handler;
+      interrupt_pointer actual_handler = get_vector_table()[event_number];
+
+      expect(that % expected_handler == actual_handler);
+      expect(that % (1 << event_number) == iser);
     };
 
-    should("interrupt::enable(17)") = [&]() {
+    should("enable_interrupt(my_enum::uart0)") = [&]() {
       // Setup
-      static constexpr std::uint16_t expected_event_number = 17;
-      static constexpr std::uint16_t shifted_event_number =
-        (expected_event_number - interrupt::core_interrupts);
-      unsigned index = shifted_event_number >> 5;
-      unsigned bit_position = shifted_event_number & 0x1F;
+      static constexpr auto event_number = my_irq::uart0;
+      unsigned index = static_cast<irq_t>(event_number) >> 5;
+      unsigned bit_position = static_cast<irq_t>(event_number) & 0x1F;
 
       // Exercise
-      interrupt(expected_event_number).enable(dummy_handler);
+      enable_interrupt(event_number, dummy_handler);
 
       // Verify
+      expect(verify_vector_enabled(event_number, dummy_handler))
+        << "event number " << static_cast<irq_t>(event_number)
+        << " did not have the appropriate handler (" << &dummy_handler
+        << ") installed";
       expect(that % dummy_handler ==
-             interrupt::get_vector_table()[expected_event_number]);
-      std::uint32_t iser = (1U << bit_position) & nvic->iser.at(index);
-      expect(that % (1 << shifted_event_number) == iser);
+             get_vector_table()[static_cast<irq_t>(event_number)]);
+      std::uint32_t iser = (1U << bit_position) | nvic->iser.at(index);
+      expect(that % (1 << bit_position) == iser);
     };
 
-    should("interrupt::enable(5)") = [&]() {
+    should("enable_interrupt(-5)") = [&]() {
       // Setup
-      static constexpr std::uint16_t expected_event_number = 5;
+      static constexpr irq_t event_number = -5;
       const auto old_nvic = *nvic;
 
       // Exercise
-      interrupt(expected_event_number).enable(dummy_handler);
+      enable_interrupt(event_number, dummy_handler);
 
       // Verify
       // Verify: That the dummy handler was added to the IVT (ISER)
-      expect(that % dummy_handler ==
-             interrupt::get_vector_table()[expected_event_number]);
+      expect(verify_vector_enabled(event_number, dummy_handler))
+        << "event number " << event_number
+        << " did not have the appropriate handler (" << &dummy_handler
+        << ") installed";
+
       // Verify: ISER[] should not have changed when enable() succeeds but the
       // IRQ is less than 0.
       for (size_t i = 0; i < old_nvic.iser.size(); i++) {
-        expect(old_nvic.iser.at(i) == nvic->iser.at(i));
+        expect(that % old_nvic.iser.at(i) == nvic->iser.at(i));
       }
     };
 
-    should("interrupt::enable(100) fail") = [&]() {
+    should("enable_interrupt(100) fail") = [&]() {
       // Setup
       // Setup: Re-initialize interrupts which will set each vector to "nop"
-      interrupt::reinitialize<expected_interrupt_count>();
-      static constexpr std::uint16_t expected_event_number = 100;
+      revert_interrupt_vector_table();
+      initialize_interrupts<my_irq::max>();
+
+      static constexpr std::uint16_t event_number = 100;
       const auto old_nvic = *nvic;
 
       // Exercise
-      interrupt(expected_event_number).enable(dummy_handler);
+      enable_interrupt(event_number, dummy_handler);
 
-      // Verify
-      // Verify: Nothing in the interrupt vector table should have changed
-      auto top_of_stack_expected = reinterpret_cast<void*>(top_of_stack);
-      auto reset_handler_expected = reinterpret_cast<void*>(reset_handler);
+      // Verify: that the state of the IVT and enable registers has not changed.
+      auto top_of_stack = get_vector_table()[hal::value(irq::top_of_stack)];
+      auto reset = get_vector_table()[hal::value(irq::reset)];
+      auto non_maskable_interrupt =
+        get_vector_table()[hal::value(irq::non_maskable_interrupt)];
+      auto hard_fault = get_vector_table()[hal::value(irq::hard_fault)];
+      auto memory_management_fault =
+        get_vector_table()[hal::value(irq::memory_management_fault)];
+      auto bus_fault = get_vector_table()[hal::value(irq::bus_fault)];
+      auto usage_fault = get_vector_table()[hal::value(irq::usage_fault)];
+      auto reserve7 = get_vector_table()[hal::value(irq::reserve7)];
+      auto reserve8 = get_vector_table()[hal::value(irq::reserve8)];
+      auto reserve9 = get_vector_table()[hal::value(irq::reserve9)];
+      auto reserve10 = get_vector_table()[hal::value(irq::reserve10)];
+      auto software_call = get_vector_table()[hal::value(irq::software_call)];
+      auto reserve12 = get_vector_table()[hal::value(irq::reserve12)];
+      auto reserve13 = get_vector_table()[hal::value(irq::reserve13)];
+      auto pend_sv = get_vector_table()[hal::value(irq::pend_sv)];
+      auto systick = get_vector_table()[hal::value(irq::systick)];
 
-      auto ivt_0 = interrupt::get_vector_table()[0];
-      auto ivt_1 = interrupt::get_vector_table()[1];
-      auto top_of_stack_actual = reinterpret_cast<void*>(ivt_0);
-      auto reset_handler_actual = reinterpret_cast<void*>(ivt_1);
+      expect(that % reinterpret_cast<void*>(&fake_top_of_stack) ==
+             reinterpret_cast<void*>(top_of_stack));
+      expect(that % reinterpret_cast<void*>(&fake_reset_handler) ==
+             reinterpret_cast<void*>(reset));
+      expect(that % reinterpret_cast<void*>(&default_interrupt_handler) ==
+             reinterpret_cast<void*>(non_maskable_interrupt));
+      expect(that % reinterpret_cast<void*>(&hard_fault_handler) ==
+             reinterpret_cast<void*>(hard_fault));
+      expect(that % reinterpret_cast<void*>(&usage_fault_handler) ==
+             reinterpret_cast<void*>(usage_fault));
+      expect(that % reinterpret_cast<void*>(&bus_fault_handler) ==
+             reinterpret_cast<void*>(bus_fault));
+      expect(that % reinterpret_cast<void*>(&memory_management_fault_handler) ==
+             reinterpret_cast<void*>(memory_management_fault));
 
-      expect(that % top_of_stack_expected == top_of_stack_actual);
-      expect(that % reset_handler_expected == reset_handler_actual);
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve7));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve8));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve9));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve10));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(software_call));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve12));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve13));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(pend_sv));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(systick));
 
-      for (const auto interrupt_function :
-           interrupt::get_vector_table().subspan(2)) {
-        auto nop_address = reinterpret_cast<void*>(&interrupt::nop);
-        auto function_address = reinterpret_cast<void*>(interrupt_function);
-        expect(that % nop_address == function_address);
+      for (const auto interrupt_function : get_vector_table()) {
+        expect(that % (void*)&default_interrupt_handler ==
+               (void*)interrupt_function);
       }
 
       // Verify: ISER[] should not have changed when enable() fails.
@@ -178,59 +223,58 @@ void interrupt_test()
     };
   };
 
-  should("interrupt(expected_event_number).disable()") = [&] {
-    should("interrupt(expected_event_number).disable(21)") = [&]() {
+  should("disable_interrupt(event_number)") = [&] {
+    should("disable_interrupt(21)") = [&]() {
       // Setup
-      static constexpr std::uint16_t expected_event_number = 21;
-      static constexpr std::uint16_t shifted_event_number =
-        (expected_event_number - interrupt::core_interrupts);
-      unsigned index = static_cast<uint32_t>(shifted_event_number) >> 5;
-      unsigned bit_position =
-        static_cast<uint32_t>(shifted_event_number) & 0x1F;
+      static constexpr std::uint16_t event_number = 21;
+      unsigned index = event_number >> 5;
+      unsigned bit_position = event_number & 0x1F;
 
       // Exercise
-      interrupt(expected_event_number).disable();
+      disable_interrupt(event_number);
 
       // Verify
-      expect(that % &interrupt::nop ==
-             interrupt::get_vector_table()[expected_event_number]);
-
-      std::uint32_t icer = (1U << bit_position) & nvic->icer.at(index);
-      expect(that % (1 << shifted_event_number) == icer);
+      std::uint32_t icer = (1U << bit_position) | nvic->icer.at(index);
+      expect(that % (1 << event_number) == icer);
     };
 
-    should("interrupt(expected_event_number).disable(17)") = [&]() {
+    should("disable_interrupt(my_irq::uart0)") = [&]() {
       // Setup
-      static constexpr int expected_event_number = 17;
-      static constexpr std::uint16_t shifted_event_number =
-        (expected_event_number - interrupt::core_interrupts);
-      unsigned index = static_cast<uint32_t>(shifted_event_number) >> 5;
-      unsigned bit_position =
-        static_cast<uint32_t>(shifted_event_number) & 0x1F;
+      static constexpr auto event_number = my_irq::uart0;
+      unsigned index = static_cast<irq_t>(event_number) >> 5;
+      unsigned bit_position = static_cast<irq_t>(event_number) & 0x1F;
 
       // Exercise
-      interrupt(expected_event_number).disable();
+      disable_interrupt(event_number);
 
       // Verify
-      expect(that % &interrupt::nop ==
-             interrupt::get_vector_table()[expected_event_number]);
-
-      std::uint32_t icer = (1U << bit_position) & nvic->icer.at(index);
-      expect(that % (1 << shifted_event_number) == icer);
+      std::uint32_t icer = (1U << bit_position) | nvic->icer.at(index);
+      expect(that % (1 << bit_position) == icer);
     };
 
-    should("interrupt(expected_event_number).disable(5)") = [&]() {
+    should("disable_interrupt(my_irq::spi7)") = [&]() {
       // Setup
-      static constexpr std::uint16_t expected_event_number = 5;
+      static constexpr auto event_number = my_irq::uart0;
+      unsigned index = static_cast<irq_t>(event_number) >> 5;
+      unsigned bit_position = static_cast<irq_t>(event_number) & 0x1F;
+
+      // Exercise
+      disable_interrupt(event_number);
+
+      // Verify
+      std::uint32_t icer = (1U << bit_position) | nvic->icer.at(index);
+      expect(that % (1 << bit_position) == icer);
+    };
+
+    should("disable_interrupt(-5)") = [&]() {
+      // Setup
+      static constexpr std::uint16_t event_number = -5;
       const auto old_nvic = *nvic;
 
       // Exercise
-      interrupt(expected_event_number).disable();
+      disable_interrupt(event_number);
 
       // Verify
-      // Verify: That the dummy handler was added to the IVT (icer )
-      expect(that % &interrupt::nop ==
-             interrupt::get_vector_table()[expected_event_number]);
       // Verify: icer[] should not have changed when disable() succeeds but the
       // IRQ is less than 0.
       for (size_t i = 0; i < old_nvic.icer.size(); i++) {
@@ -238,52 +282,102 @@ void interrupt_test()
       }
     };
 
-    should("interrupt(expected_event_number).disable(100) fail") = [&]() {
+    should("disable_interrupt(100) fail") = [&]() {
       // Setup
       // Setup: Re-initialize interrupts which will set each vector to "nop"
-      interrupt::reinitialize<expected_interrupt_count>();
-      static constexpr int expected_event_number = 100;
+      revert_interrupt_vector_table();
+      initialize_interrupts<my_irq::max>();
+      static constexpr int event_number = 100;
       const auto old_nvic = *nvic;
 
       // Exercise
-      interrupt(expected_event_number).disable();
+      disable_interrupt(event_number);
 
-      // Verify: Nothing in the interrupt vector table should have changed
-      auto top_of_stack_expected = reinterpret_cast<void*>(top_of_stack);
-      auto reset_handler_expected = reinterpret_cast<void*>(reset_handler);
+      // Verify: that the state of the IVT and enable registers has not changed.
+      auto top_of_stack = get_vector_table()[hal::value(irq::top_of_stack)];
+      auto reset = get_vector_table()[hal::value(irq::reset)];
+      auto non_maskable_interrupt =
+        get_vector_table()[hal::value(irq::non_maskable_interrupt)];
+      auto hard_fault = get_vector_table()[hal::value(irq::hard_fault)];
+      auto memory_management_fault =
+        get_vector_table()[hal::value(irq::memory_management_fault)];
+      auto bus_fault = get_vector_table()[hal::value(irq::bus_fault)];
+      auto usage_fault = get_vector_table()[hal::value(irq::usage_fault)];
+      auto reserve7 = get_vector_table()[hal::value(irq::reserve7)];
+      auto reserve8 = get_vector_table()[hal::value(irq::reserve8)];
+      auto reserve9 = get_vector_table()[hal::value(irq::reserve9)];
+      auto reserve10 = get_vector_table()[hal::value(irq::reserve10)];
+      auto software_call = get_vector_table()[hal::value(irq::software_call)];
+      auto reserve12 = get_vector_table()[hal::value(irq::reserve12)];
+      auto reserve13 = get_vector_table()[hal::value(irq::reserve13)];
+      auto pend_sv = get_vector_table()[hal::value(irq::pend_sv)];
+      auto systick = get_vector_table()[hal::value(irq::systick)];
 
-      auto ivt_0 = interrupt::get_vector_table()[0];
-      auto ivt_1 = interrupt::get_vector_table()[1];
-      auto top_of_stack_actual = reinterpret_cast<void*>(ivt_0);
-      auto reset_handler_actual = reinterpret_cast<void*>(ivt_1);
+      expect(that % reinterpret_cast<void*>(&fake_top_of_stack) ==
+             reinterpret_cast<void*>(top_of_stack));
+      expect(that % reinterpret_cast<void*>(&fake_reset_handler) ==
+             reinterpret_cast<void*>(reset));
+      expect(that % reinterpret_cast<void*>(&default_interrupt_handler) ==
+             reinterpret_cast<void*>(non_maskable_interrupt));
+      expect(that % reinterpret_cast<void*>(&hard_fault_handler) ==
+             reinterpret_cast<void*>(hard_fault));
+      expect(that % reinterpret_cast<void*>(&usage_fault_handler) ==
+             reinterpret_cast<void*>(usage_fault));
+      expect(that % reinterpret_cast<void*>(&bus_fault_handler) ==
+             reinterpret_cast<void*>(bus_fault));
+      expect(that % reinterpret_cast<void*>(&memory_management_fault_handler) ==
+             reinterpret_cast<void*>(memory_management_fault));
 
-      expect(that % top_of_stack_expected == top_of_stack_actual);
-      expect(that % reset_handler_expected == reset_handler_actual);
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve7));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve8));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve9));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve10));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(software_call));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve12));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(reserve13));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(pend_sv));
+      expect(that % &default_interrupt_handler ==
+             reinterpret_cast<void*>(systick));
 
-      for (const auto interrupt_function :
-           interrupt::get_vector_table().subspan(2)) {
-        auto nop_address = reinterpret_cast<void*>(&interrupt::nop);
-        auto function_address = reinterpret_cast<void*>(interrupt_function);
-        expect(that % nop_address == function_address);
+      for (const auto interrupt_function : get_vector_table()) {
+        expect(that % (void*)&default_interrupt_handler ==
+               (void*)interrupt_function);
       }
 
-      // Verify: icer[] should not have changed when disable() fails.
-      for (size_t i = 0; i < old_nvic.icer.size(); i++) {
-        expect(old_nvic.icer.at(i) == nvic->icer.at(i));
+      // Verify: ISER[] should not have changed when enable() fails.
+      for (size_t i = 0; i < old_nvic.iser.size(); i++) {
+        expect(old_nvic.iser.at(i) == nvic->iser.at(i));
       }
     };
   };
 
-  should("interrupt::get_vector_table()") = [&] {
+  should("get_vector_table()") = [&] {
     // Setup
-    expect(that % nullptr != interrupt::get_vector_table().data());
-    expect(that % 0 != interrupt::get_vector_table().size());
+    expect(that % nullptr != get_vector_table().data());
+    expect(that % 0 != get_vector_table().size());
 
     // Exercise & Verify
-    expect(interrupt::get_vector_table().data() ==
-           interrupt::get_vector_table().data());
-    expect(that % interrupt::get_vector_table().size() ==
-           interrupt::get_vector_table().size());
+    expect(get_vector_table().data() == get_vector_table().data());
+    expect(that % get_vector_table().size() == get_vector_table().size());
+  };
+
+  should("interrupt_vector_table_initialized()") = [&] {
+    expect(interrupt_vector_table_initialized());
+  };
+
+  should("disable_all_interrupts() & enable_all_interrupts() works") = [&] {
+    // these are empty on host builds as the instruction for these will not work
+    // any host that isn't a cortex-m mcu.
+    disable_all_interrupts();
+    enable_all_interrupts();
   };
 };
 }  // namespace hal::cortex_m

--- a/tests/systick_timer.test.cpp
+++ b/tests/systick_timer.test.cpp
@@ -14,11 +14,10 @@
 
 #include <libhal-armcortex/systick_timer.hpp>
 
+#include <libhal-armcortex/interrupt.hpp>
 #include <libhal/units.hpp>
 
 #include "helper.hpp"
-#include "interrupt_reg.hpp"
-#include "system_controller_reg.hpp"
 #include "systick_timer_reg.hpp"
 
 #include <boost/ut.hpp>
@@ -30,9 +29,9 @@ void systick_timer_test()
   using namespace std::chrono_literals;
   using namespace hal::literals;
 
+  auto saved_registers = setup_interrupts_for_unit_testing();
   auto stub_out_sys_tick = stub_out_registers(&sys_tick);
-  auto stub_out_nvic = stub_out_registers(&nvic);
-  auto stub_out_scb = stub_out_registers(&scb);
+  initialize_interrupts<1>();
   systick_timer test_subject(1.0_MHz);
 
   should("systick_timer::systick_timer()") = [&] {


### PR DESCRIPTION
The previous interrupt APIs were born from libhal 1.0.0 where the policy was to use header only libraries for all code. classes and structs make building header only libraries quite easy along with the ability to hide state in private sections. This is no longer needed now that we are building all of our binaries and can use source files.

The goal of this change was to make the interrupt APIs a bit more reasonable. Rather than `interrupt(irq_t).enable(handler)`, we simply have `enable_interrupt(irq_t, handler)`. All of the APis were changed to get rid of a lot of the unnecessary OOP we were doing to hide state.

This is a breaking API change that I believe needs to get in now before there are too many platform libraries running about that will need to be refactored later.

Also, negative IRQ types are now allowed for the cortex IRQ numbers. This removes the need for platform developers to do the following when creating their irq enumeration classes.

```
/// List of interrupt request numbers for this platform
enum class irq : std::uint16_t
{
  wdt = 16 + 0,
  timer0 = 16 + 1,
  timer1 = 16 + 2,
  // etc...
  max,
};
```

Now it can just be:

```
/// List of interrupt request numbers for this platform
enum class irq : std::uint16_t
{
  wdt = 0,
  timer0 = 1,
  timer1 = 2,
  // etc...
  max,
};
```

Which is more natural and ergonomic.