### PR TITLE
:bug: Fix interrupts & systick timer

### DIFF
--- a/.github/workflows/5.0.1.yml
+++ b/.github/workflows/5.0.1.yml
@@ -1,0 +1,11 @@
+name: 🚀 Release 5.0.1
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/deploy-version.yml
+    with:
+      version: 5.0.1
+    secrets: inherit

--- a/src/interrupt.cpp
+++ b/src/interrupt.cpp
@@ -84,7 +84,7 @@ void setup_default_vector_table(std::span<interrupt_pointer> p_vector_table)
 constexpr bool is_the_same_vector_buffer(
   std::span<interrupt_pointer> p_vector_table)
 {
-  p_vector_table = p_vector_table.subspan(core_interrupts);
+  p_vector_table = p_vector_table.subspan(-core_interrupts);
   return (p_vector_table.data() == vector_table.data() &&
           p_vector_table.size() == vector_table.size());
 }

--- a/src/systick_timer.cpp
+++ b/src/systick_timer.cpp
@@ -77,7 +77,7 @@ void systick_timer::register_cpu_frequency(hertz p_frequency,
 systick_timer::~systick_timer()
 {
   stop();
-  disable_interrupt(event_number);
+  disable_interrupt(irq::systick);
 }
 
 bool systick_timer::driver_is_running()
@@ -117,7 +117,7 @@ void systick_timer::driver_schedule(hal::callback<void(void)> p_callback,
 
   // Enable interrupt service routine for SysTick and use this callback as the
   // handler
-  enable_interrupt(event_number, handler.get_handler());
+  enable_interrupt(irq::systick, handler.get_handler());
 
   sys_tick->current_value = 0;
   sys_tick->reload = static_cast<uint32_t>(cycle_count);

--- a/src/systick_timer_reg.hpp
+++ b/src/systick_timer_reg.hpp
@@ -58,8 +58,6 @@ static constexpr auto count_flag = hal::bit_mask::from<16>();
 
 /// The address of the sys_tick register
 inline constexpr std::intptr_t systick_address = 0xE000'E010UL;
-/// The IRQ number for the SysTick interrupt vector
-inline constexpr std::uint16_t event_number = 15;
 
 /// @return auto* - Address of the ARM Cortex SysTick peripheral
 inline auto* sys_tick = reinterpret_cast<systick_register_t*>(systick_address);


### PR DESCRIPTION
The initialize_interrupts was re-initializing the vector table due to bad logic in `is_the_same_vector_buffer`.

`hal::cortex_m::systick_timer` now uses the correct irq value.